### PR TITLE
Fixed unhandled error in setup dialog.  this bug was introduced in 1.1

### DIFF
--- a/windows/ascom-sources/SetupDialogForm.vb
+++ b/windows/ascom-sources/SetupDialogForm.vb
@@ -92,16 +92,30 @@ Public Class SetupForm
             CalibrateButton.Enabled = False
         End If
         TimeSinceWake = TimeSinceWake + 1
-        ' The sleep timer is in 1/1000 of a second
-        ' if it more than half expired since the last wakeup
-        ' send another wakeup
-        ti = Dome.ShutterSleepTimer
-        ti = ti / 1000
-        ti = ti / 2
 
-        If (TimeSinceWake > ti) Then
-            MyDome.DomeCommand("x")
-            TimeSinceWake = 0
+
+        ' This is important.  If the DomeCommand("x") is issued while the dome is
+        ' calibrating or homing the calibration/homing will never end, it continues foreever.
+        ' This will also throw an occasional unhandled exception and then all bets are off.
+        If Not (Dome.isCalibrating Or Dome.isHoming) Then
+
+            ' The sleep timer is in 1/1000 of a second
+            ' if it more than half expired since the last wakeup
+            ' send another wakeup
+            ti = Dome.ShutterSleepTimer
+            ti = ti / 1000
+            ti = ti / 2
+
+            If (TimeSinceWake > ti) Then
+                Try
+                    MyDome.DomeCommand("x")
+                    TimeSinceWake = 0
+                Catch ex As Exception
+                    ' Handling the random unhandle exception.  
+                    ' Should log it somewhere?
+                End Try
+            
+            End If
         End If
 
     End Sub


### PR DESCRIPTION
Hi Gerry,

Here is the pull request for the change I have made.  It fixes 2 issues in one shot.

1) The DomeCommand("x") is wrapped in a try catch clause to catch the random unhandled error.  The error is not logged but you do have logging implemented (I did not go look for one) it might be a good thing to log it.
2) The shuttersleeptimer code is only executed if your are not calibrating or homing otherwise the calibration and/or homing process never ends, it will run forever.  

Please test at least 1 calibration and 1 homing... and also test the shutter wake up if it is still working.  I don't have the shutter so I can't test this.

Regards,